### PR TITLE
Wrap this as a Go module

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.14
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.14
       id: go
 
     - name: Check out code into the Go module directory

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Go CPF ![Tests](https://github.com/cuducos/go-cpf/workflows/Tests/badge.svg)
+# Go CPF [![Tests](https://github.com/cuducos/go-cpf/workflows/Tests/badge.svg)]()[![GoDoc](https://godoc.org/github.com/cuducos/go-cpf?status.svg)](https://godoc.org/github.com/cuducos/go-cpf)![Go version](https://img.shields.io/github/go-mod/go-version/cuducos/go-cpf)
 
 A Go module to validate CPF numbers (Brazilian unique identifier for the Federal Revenue).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,32 @@
-# Go CPF
+# Go CPF ![Tests](https://github.com/cuducos/go-cpf/workflows/Tests/badge.svg)
 
-Three things about this repo:
+A Go module to validate CPF numbers (Brazilian unique identifier for the Federal Revenue).
 
-1. I just started to learn [Go](https://golang.org/) with [_Learn Go With Tests_](https://quii.gitbook.io/learn-go-with-tests/) and this CPF (Brazilian unique identifier for the Federal Revenue) validation script is actually **my very first lines in Go** (except the ones from the book)
-2. I'm sharing it here to get **feedback** ❤️
-3. It's not a proper or usable package yet, I just expect **`go test`** to pass : )
+```go
+package main
+
+import "github.com/cuducos/go-cpf"
+
+
+func main() {
+	// these return true
+	cpf.IsValid("23858488135")
+	cpf.IsValid("238.584.881-35")
+
+	// these return false
+	cpf.IsValid("111.111.111-11")
+	cpf.IsValid("123.456.769/01")
+	cpf.IsValid("ABC.DEF.GHI-JK")
+	cpf.IsValid("123")
+
+	// this returns 11111111111
+	cpf.Unmask("111.111.111-11")
+
+	// this returns 111.111.111-11
+	cpf.Mask("11111111111")
+}
+```
+
+## A bit of story and thankfulness
+
+I started to learn [Go](https://golang.org/) with [_Learn Go With Tests_](https://quii.gitbook.io/learn-go-with-tests/) and this CPF (Brazilian unique identifier for the Federal Revenue) validation script is actually **my very first lines in Go** (except the ones from the book). I'm sharing it here to get **feedback** ❤️

--- a/cpf.go
+++ b/cpf.go
@@ -7,17 +7,11 @@ import (
 	"strings"
 )
 
-//auxiliar type and variable to build a set
+//These are auxiliar type and variable to build a set
 type void struct{}
 
 var member void
 
-//Cpf type
-type Cpf string
-
-func (c Cpf) String() string {
-	return string(c)
-}
 
 func checksum(ds []int64) int64 {
 	var s int64
@@ -31,9 +25,9 @@ func checksum(ds []int64) int64 {
 	return r
 }
 
-//IsValid checks whether Cpf number is valid or not
-func (c Cpf) IsValid() bool {
-	u := c.Unmask()
+//IsValid checks whether CPF number is valid or not
+func  IsValid(n string) bool {
+	u := Unmask(n)
 
 	if len(u) != 11 {
 		return false
@@ -50,7 +44,7 @@ func (c Cpf) IsValid() bool {
 		s[c] = member
 	}
 
-	//If all digits are the same, the Cpf is not valid
+	//If all digits are the same, the CPF is not valid
 	if len(s) == 1 {
 		return false
 	}
@@ -58,16 +52,16 @@ func (c Cpf) IsValid() bool {
 	return checksum(ds[:9]) == ds[9] && checksum(ds[:10]) == ds[10]
 }
 
-//Mask returns the Cpf number formatted
-func (c Cpf) Mask() string {
-	u := c.Unmask()
+//Mask returns the CPF number formatted
+func  Mask(n string) string {
+	u := Unmask(n)
 	if len(u) != 11 {
-		return string(c)
+		return n
 	}
 	return fmt.Sprintf("%s.%s.%s-%s", u[:3], u[3:6], u[6:9], u[9:])
 }
 
-//Unmask removes any non-digit (numeric) from the Cpf
-func (c Cpf) Unmask() string {
-	return regexp.MustCompile(`\D`).ReplaceAllString(string(c), "")
+//Unmask removes any non-digit (numeric) from the CPF number
+func  Unmask(n string) string {
+	return regexp.MustCompile(`\D`).ReplaceAllString(n, "")
 }

--- a/cpf_test.go
+++ b/cpf_test.go
@@ -11,32 +11,32 @@ func TestMask(t *testing.T) {
 		{"123456", "123456"},
 		{"11223344556677889900", "11223344556677889900"},
 	} {
-		if got := Cpf(tc.cpf).Mask(); tc.expected != got {
-			t.Errorf("Cpf(\"%s\").Mask() = %v; want %s", tc.cpf, got, tc.expected)
+		if got := Mask(tc.cpf); tc.expected != got {
+			t.Errorf("Mask(\"%s\") = %v; expected %s", tc.cpf, got, tc.expected)
 		}
 	}
 }
 
 func TestUnmask(t *testing.T) {
-	if got := Cpf("111.111.111-11").Unmask(); "11111111111" != got {
-		t.Errorf("Cpf(\"111.111.111-11\").Unmask() = %v; want 11111111111", got)
+	if got := Unmask("111.111.111-11"); "11111111111" != got {
+		t.Errorf("Unmask(\"111.111.111-11\") = %v; want 11111111111", got)
 	}
 }
 
 func TestIsValid(t *testing.T) {
 	for _, tc := range []struct {
-		cpf      Cpf
+		cpf      string
 		expected bool
 	}{
-		{Cpf("23858488135"), true},
-		{Cpf("238.584.881-35"), true},
-		{Cpf("123"), false},
-		{Cpf("111.111.111-11"), false},
-		{Cpf("123.456.769/01"), false},
-		{Cpf("ABC.DEF.GHI-JK"), false},
+		{"23858488135", true},
+		{"238.584.881-35", true},
+		{"123", false},
+		{"111.111.111-11", false},
+		{"123.456.769/01", false},
+		{"ABC.DEF.GHI-JK", false},
 	} {
-		if got := tc.cpf.IsValid(); tc.expected != got {
-			t.Errorf("Cpf(%v).IsValid() = %v; want %v", tc.cpf, got, tc.expected)
+		if got := IsValid(tc.cpf); tc.expected != got {
+			t.Errorf("IsValid(%v) = %v; expected %v", tc.cpf, got, tc.expected)
 		}
 	}
 }

--- a/cpf_test.go
+++ b/cpf_test.go
@@ -1,6 +1,9 @@
 package cpf
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestMask(t *testing.T) {
 	for _, tc := range []struct {
@@ -39,4 +42,34 @@ func TestIsValid(t *testing.T) {
 			t.Errorf("IsValid(%v) = %v; expected %v", tc.cpf, got, tc.expected)
 		}
 	}
+}
+
+func ExampleIsValid_validUnmasked() {
+	fmt.Println(IsValid("23858488135"))
+	// Output: true
+}
+
+func ExampleIsValid_validMasked() {
+	fmt.Println(IsValid("238.584.881-35"))
+	// Output: true
+}
+
+func ExampleIsValid_invalid() {
+	fmt.Println(IsValid("111.111.111-11"))
+	// Output: false
+}
+
+func ExampleMask_valid() {
+	fmt.Println(Mask("11111111111"))
+	// Output: 111.111.111-11
+}
+
+func ExampleMask_invalid() {
+	fmt.Println(Mask("42"))
+	// Output: 42
+}
+
+func ExampleUnmask() {
+	fmt.Println(Unmask("111.111.111-11"))
+	// Output: 11111111111
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/cuducos/go-cpf
+
+go 1.14


### PR DESCRIPTION
I'm attempting to wrap this code as a Go module to use elsewhere.

I know I still need to tag a version, `v0.0.1`, probably, but my idea is to do that once this code reaches the `master` branch.

Thus, what is packed in this PR:

1. I created a `go.mod`
1. I removed the `Cpf` type to enhance the API
1. I added a snippet as an example in the `README.md` (not sure how to test it before actually publishing the thing, though)
1. Added examples to the docs
1. Added badges to the `README.md`